### PR TITLE
Recover some US-specific titles from old metadata

### DIFF
--- a/indicator-config/1-2-1.yml
+++ b/indicator-config/1-2-1.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,12 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.1-2-1-title
+graph_title: Percent of US population living below the US poverty line
 graph_titles: []
 graph_type: line
+indicator_available: Percent of US population living below the US poverty line
 indicator_name: global_indicators.1-2-1-title
-indicator_number: '1.2.1'
+indicator_number: 1.2.1
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/1-3-1.yml
+++ b/indicator-config/1-3-1.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,14 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.1-3-1-title
+graph_title: Percent of population who have earned Social Security retirement, survivors
+  and disability insurance coverage
 graph_titles: []
 graph_type: line
+indicator_available: Percent of population who have earned Social Security retirement,
+  survivors and disability insurance coverage
 indicator_name: global_indicators.1-3-1-title
-indicator_number: '1.3.1'
+indicator_number: 1.3.1
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/1-5-1.yml
+++ b/indicator-config/1-5-1.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,13 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.1-5-1-title
+graph_title: Has the US established national and local disaster risk reduction strategies?
 graph_titles: []
 graph_type: line
+indicator_available: Has the US established national and local disaster risk reduction
+  strategies?
 indicator_name: global_indicators.1-5-1-title
-indicator_number: '1.5.1'
+indicator_number: 1.5.1
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/1-5-2.yml
+++ b/indicator-config/1-5-2.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,12 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.1-5-2-title
+graph_title: Disaster losses as a percentage of GDP
 graph_titles: []
 graph_type: line
+indicator_available: Disaster losses as a percentage of GDP
 indicator_name: global_indicators.1-5-2-title
-indicator_number: '1.5.2'
+indicator_number: 1.5.2
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/1-5-3.yml
+++ b/indicator-config/1-5-3.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,13 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.1-5-3-title
+graph_title: Has the US established national and local disaster risk reduction strategies?
 graph_titles: []
 graph_type: line
+indicator_available: Has the US established national and local disaster risk reduction
+  strategies?
 indicator_name: global_indicators.1-5-3-title
-indicator_number: '1.5.3'
+indicator_number: 1.5.3
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/1-5-4.yml
+++ b/indicator-config/1-5-4.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,13 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.1-5-4-title
+graph_title: Has the US established national and local disaster risk reduction strategies?
 graph_titles: []
 graph_type: line
+indicator_available: Has the US established national and local disaster risk reduction
+  strategies?
 indicator_name: global_indicators.1-5-4-title
-indicator_number: '1.5.4'
+indicator_number: 1.5.4
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/10-1-1.yml
+++ b/indicator-config/10-1-1.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,12 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.10-1-1-title
+graph_title: US growth rate of income per capita for the total population
 graph_titles: []
 graph_type: line
+indicator_available: US growth rate of income per capita for the total population
 indicator_name: global_indicators.10-1-1-title
-indicator_number: '10.1.1'
+indicator_number: 10.1.1
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/10-4-1.yml
+++ b/indicator-config/10-4-1.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,12 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.10-4-1-title
+graph_title: US share of labor compensation in GDP in current national prices
 graph_titles: []
 graph_type: line
+indicator_available: US share of labor compensation in GDP in current national prices
 indicator_name: global_indicators.10-4-1-title
-indicator_number: '10.4.1'
+indicator_number: 10.4.1
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/11-1-1.yml
+++ b/indicator-config/11-1-1.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,14 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.11-1-1-title
+graph_title: Percentage of occupied housing units in US urban areas that are severely
+  inadequate
 graph_titles: []
 graph_type: line
+indicator_available: Percentage of occupied housing units in US urban areas that are
+  severely inadequate
 indicator_name: global_indicators.11-1-1-title
-indicator_number: '11.1.1'
+indicator_number: 11.1.1
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/11-5-1.yml
+++ b/indicator-config/11-5-1.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,13 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.11-5-1-title
+graph_title: Has the US established national and local disaster risk reduction strategies?
 graph_titles: []
 graph_type: line
+indicator_available: Has the US established national and local disaster risk reduction
+  strategies?
 indicator_name: global_indicators.11-5-1-title
-indicator_number: '11.5.1'
+indicator_number: 11.5.1
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/11-5-2.yml
+++ b/indicator-config/11-5-2.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,12 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.11-5-2-title
+graph_title: Disaster losses as a percentage of GDP
 graph_titles: []
 graph_type: line
+indicator_available: Disaster losses as a percentage of GDP
 indicator_name: global_indicators.11-5-2-title
-indicator_number: '11.5.2'
+indicator_number: 11.5.2
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/11-6-2.yml
+++ b/indicator-config/11-6-2.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,12 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.11-6-2-title
+graph_title: Annual mean levels of PM2.5 in US cities weighted by population
 graph_titles: []
 graph_type: line
+indicator_available: Annual mean levels of PM2.5 in US cities weighted by population
 indicator_name: global_indicators.11-6-2-title
-indicator_number: '11.6.2'
+indicator_number: 11.6.2
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/11-b-1.yml
+++ b/indicator-config/11-b-1.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,13 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.11-b-1-title
+graph_title: Has the US established national and local disaster risk reduction strategies?
 graph_titles: []
 graph_type: line
+indicator_available: Has the US established national and local disaster risk reduction
+  strategies?
 indicator_name: global_indicators.11-b-1-title
-indicator_number: '11.b.1'
+indicator_number: 11.b.1
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/11-b-2.yml
+++ b/indicator-config/11-b-2.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,13 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.11-b-2-title
+graph_title: Has the US established national and local disaster risk reduction strategies?
 graph_titles: []
 graph_type: line
+indicator_available: Has the US established national and local disaster risk reduction
+  strategies?
 indicator_name: global_indicators.11-b-2-title
-indicator_number: '11.b.2'
+indicator_number: 11.b.2
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/12-2-2.yml
+++ b/indicator-config/12-2-2.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,14 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.12-2-2-title
+graph_title: US personal consumption expenditure (goods) per capita in millions of
+  US dollars
 graph_titles: []
 graph_type: line
+indicator_available: US personal consumption expenditure (goods) per capita in millions
+  of US dollars
 indicator_name: global_indicators.12-2-2-title
-indicator_number: '12.2.2'
+indicator_number: 12.2.2
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/12-4-1.yml
+++ b/indicator-config/12-4-1.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,12 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.12-4-1-title
+graph_title: Is the US in compliance with the Montreal Protocol ?
 graph_titles: []
 graph_type: line
+indicator_available: Is the US in compliance with the Montreal Protocol ?
 indicator_name: global_indicators.12-4-1-title
-indicator_number: '12.4.1'
+indicator_number: 12.4.1
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/13-1-1.yml
+++ b/indicator-config/13-1-1.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,13 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.13-1-1-title
+graph_title: Has the US established national and local disaster risk reduction strategies?
 graph_titles: []
 graph_type: line
+indicator_available: Has the US established national and local disaster risk reduction
+  strategies?
 indicator_name: global_indicators.13-1-1-title
-indicator_number: '13.1.1'
+indicator_number: 13.1.1
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/13-1-2.yml
+++ b/indicator-config/13-1-2.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,13 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.13-1-2-title
+graph_title: Has the US established national and local disaster risk reduction strategies?
 graph_titles: []
 graph_type: line
+indicator_available: Has the US established national and local disaster risk reduction
+  strategies?
 indicator_name: global_indicators.13-1-2-title
-indicator_number: '13.1.2'
+indicator_number: 13.1.2
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/13-1-3.yml
+++ b/indicator-config/13-1-3.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,13 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.13-1-3-title
+graph_title: Has the US established national and local disaster risk reduction strategies?
 graph_titles: []
 graph_type: line
+indicator_available: Has the US established national and local disaster risk reduction
+  strategies?
 indicator_name: global_indicators.13-1-3-title
-indicator_number: '13.1.3'
+indicator_number: 13.1.3
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/13-2-1.yml
+++ b/indicator-config/13-2-1.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,14 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.13-2-1-title
+graph_title: Has the US established a plan to improve the nation's ability to adapt
+  to climate change in a manner that does not adversely affect food production?
 graph_titles: []
 graph_type: line
+indicator_available: Has the US established a plan to improve the nation's ability
+  to adapt to climate change in a manner that does not adversely affect food production?
 indicator_name: global_indicators.13-2-1-title
-indicator_number: '13.2.1'
+indicator_number: 13.2.1
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/13-3-1.yml
+++ b/indicator-config/13-3-1.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,15 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.13-3-1-title
+graph_title: Has the US established any form of climate change mitigation, adaption
+  and impact reduction into its primary, secondary, and tertiary educational curricula?
 graph_titles: []
 graph_type: line
+indicator_available: Has the US established any form of climate change mitigation,
+  adaption and impact reduction into its primary, secondary, and tertiary educational
+  curricula?
 indicator_name: global_indicators.13-3-1-title
-indicator_number: '13.3.1'
+indicator_number: 13.3.1
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/13-b-1.yml
+++ b/indicator-config/13-b-1.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,14 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.13-b-1-title
+graph_title: Does this indicator (LDC or small island developing states receiving
+  support) apply to the US?
 graph_titles: []
 graph_type: line
+indicator_available: Does this indicator (LDC or small island developing states receiving
+  support) apply to the US?
 indicator_name: global_indicators.13-b-1-title
-indicator_number: '13.b.1'
+indicator_number: 13.b.1
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/14-4-1.yml
+++ b/indicator-config/14-4-1.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,12 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.14-4-1-title
+graph_title: Percentage of US fish stocks at a sustainable level
 graph_titles: []
 graph_type: line
+indicator_available: Percentage of US fish stocks at a sustainable level
 indicator_name: global_indicators.14-4-1-title
-indicator_number: '14.4.1'
+indicator_number: 14.4.1
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/14-5-1.yml
+++ b/indicator-config/14-5-1.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,14 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.14-5-1-title
+graph_title: Percent of U.S. marine waters in a natural or cultural heritage marine
+  protected area
 graph_titles: []
 graph_type: line
+indicator_available: Percent of U.S. marine waters in a natural or cultural heritage
+  marine protected area
 indicator_name: global_indicators.14-5-1-title
-indicator_number: '14.5.1'
+indicator_number: 14.5.1
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/15-1-1.yml
+++ b/indicator-config/15-1-1.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,12 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.15-1-1-title
+graph_title: US Forest area as a percentage of total land area
 graph_titles: []
 graph_type: line
+indicator_available: US Forest area as a percentage of total land area
 indicator_name: global_indicators.15-1-1-title
-indicator_number: '15.1.1'
+indicator_number: 15.1.1
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/16-1-1.yml
+++ b/indicator-config/16-1-1.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,13 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.16-1-1-title
+graph_title: Estimated number of US victims of intentional homicide per 100,000 population
 graph_titles: []
 graph_type: line
+indicator_available: Estimated number of US victims of intentional homicide per 100,000
+  population
 indicator_name: global_indicators.16-1-1-title
-indicator_number: '16.1.1'
+indicator_number: 16.1.1
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/16-1-4.yml
+++ b/indicator-config/16-1-4.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,14 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.16-1-4-title
+graph_title: Percent of persons ages 18 and older who report feeling safe walking
+  near their home
 graph_titles: []
 graph_type: line
+indicator_available: Percent of persons ages 18 and older who report feeling safe
+  walking near their home
 indicator_name: global_indicators.16-1-4-title
-indicator_number: '16.1.4'
+indicator_number: 16.1.4
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/16-2-2.yml
+++ b/indicator-config/16-2-2.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,12 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.16-2-2-title
+graph_title: Number of US reported human trafficking offenses
 graph_titles: []
 graph_type: line
+indicator_available: Number of US reported human trafficking offenses
 indicator_name: global_indicators.16-2-2-title
-indicator_number: '16.2.2'
+indicator_number: 16.2.2
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/16-3-1.yml
+++ b/indicator-config/16-3-1.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,12 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.16-3-1-title
+graph_title: Percent of US violent victimizations reported to the police
 graph_titles: []
 graph_type: line
+indicator_available: Percent of US violent victimizations reported to the police
 indicator_name: global_indicators.16-3-1-title
-indicator_number: '16.3.1'
+indicator_number: 16.3.1
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/16-3-2.yml
+++ b/indicator-config/16-3-2.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,14 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.16-3-2-title
+graph_title: Percent unsentenced detainees of inmates held in US state and federal
+  prisons and local jails
 graph_titles: []
 graph_type: line
+indicator_available: Percent unsentenced detainees of inmates held in US state and
+  federal prisons and local jails
 indicator_name: global_indicators.16-3-2-title
-indicator_number: '16.3.2'
+indicator_number: 16.3.2
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/16-9-1.yml
+++ b/indicator-config/16-9-1.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,14 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.16-9-1-title
+graph_title: Percent of US births registered in all 50 states and the District of
+  Columbia
 graph_titles: []
 graph_type: line
+indicator_available: Percent of US births registered in all 50 states and the District
+  of Columbia
 indicator_name: global_indicators.16-9-1-title
-indicator_number: '16.9.1'
+indicator_number: 16.9.1
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/17-1-1.yml
+++ b/indicator-config/17-1-1.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,12 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.17-1-1-title
+graph_title: US Government current receipts as a percentage of GDP
 graph_titles: []
 graph_type: line
+indicator_available: US Government current receipts as a percentage of GDP
 indicator_name: global_indicators.17-1-1-title
-indicator_number: '17.1.1'
+indicator_number: 17.1.1
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/17-13-1.yml
+++ b/indicator-config/17-13-1.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,12 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.17-13-1-title
+graph_title: Does the USG produce dashboards of macroeconomic indicators (Y/N)?
 graph_titles: []
 graph_type: line
+indicator_available: Does the USG produce dashboards of macroeconomic indicators (Y/N)?
 indicator_name: global_indicators.17-13-1-title
-indicator_number: '17.13.1'
+indicator_number: 17.13.1
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/17-18-2.yml
+++ b/indicator-config/17-18-2.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,14 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.17-18-2-title
+graph_title: Does the US have national statistical legislation compliant with the
+  Fundamental Principles of Official Statistics?
 graph_titles: []
 graph_type: line
+indicator_available: Does the US have national statistical legislation compliant with
+  the Fundamental Principles of Official Statistics?
 indicator_name: global_indicators.17-18-2-title
-indicator_number: '17.18.2'
+indicator_number: 17.18.2
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/17-18-3.yml
+++ b/indicator-config/17-18-3.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,14 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.17-18-3-title
+graph_title: Does the US have a funded and implemented national statistics program?
+  Source of funding?
 graph_titles: []
 graph_type: line
+indicator_available: Does the US have a funded and implemented national statistics
+  program? Source of funding?
 indicator_name: global_indicators.17-18-3-title
-indicator_number: '17.18.3'
+indicator_number: 17.18.3
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/17-19-1.yml
+++ b/indicator-config/17-19-1.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,14 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.17-19-1-title
+graph_title: Dollar Value of all resources made available to strengthen statistical
+  capacity in developing countries
 graph_titles: []
 graph_type: line
+indicator_available: Dollar Value of all resources made available to strengthen statistical
+  capacity in developing countries
 indicator_name: global_indicators.17-19-1-title
-indicator_number: '17.19.1'
+indicator_number: 17.19.1
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/17-19-2.yml
+++ b/indicator-config/17-19-2.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,16 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.17-19-2-title
+graph_title: Has the US completed at least one population and housing census in the
+  last 10 years? Has the US achieved 100 percent birth registration and at least 80
+  percent death registration?
 graph_titles: []
 graph_type: line
+indicator_available: Has the US completed at least one population and housing census
+  in the last 10 years? Has the US achieved 100 percent birth registration and at
+  least 80 percent death registration?
 indicator_name: global_indicators.17-19-2-title
-indicator_number: '17.19.2'
+indicator_number: 17.19.2
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/17-3-2.yml
+++ b/indicator-config/17-3-2.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,14 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.17-3-2-title
+graph_title: Personal transfers from US resident immigrants to foreign residents as
+  a percentage of GDP
 graph_titles: []
 graph_type: line
+indicator_available: Personal transfers from US resident immigrants to foreign residents
+  as a percentage of GDP
 indicator_name: global_indicators.17-3-2-title
-indicator_number: '17.3.2'
+indicator_number: 17.3.2
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/17-4-1.yml
+++ b/indicator-config/17-4-1.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,14 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.17-4-1-title
+graph_title: Net U.S. acquisition of debt securities (outflow) as a percentage of
+  exports (goods and services)
 graph_titles: []
 graph_type: line
+indicator_available: Net U.S. acquisition of debt securities (outflow) as a percentage
+  of exports (goods and services)
 indicator_name: global_indicators.17-4-1-title
-indicator_number: '17.4.1'
+indicator_number: 17.4.1
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/17-8-1.yml
+++ b/indicator-config/17-8-1.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,12 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.17-8-1-title
+graph_title: Proportion of US individuals using the Internet (age 3 and over)
 graph_titles: []
 graph_type: line
+indicator_available: Proportion of US individuals using the Internet (age 3 and over)
 indicator_name: global_indicators.17-8-1-title
-indicator_number: '17.8.1'
+indicator_number: 17.8.1
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/2-1-2.yml
+++ b/indicator-config/2-1-2.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,12 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.2-1-2-title
+graph_title: Percent of households with food insecurity in the US
 graph_titles: []
 graph_type: line
+indicator_available: Percent of households with food insecurity in the US
 indicator_name: global_indicators.2-1-2-title
-indicator_number: '2.1.2'
+indicator_number: 2.1.2
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/2-2-1.yml
+++ b/indicator-config/2-2-1.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,12 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.2-2-1-title
+graph_title: Percent of US children ages 0 to 5 experiencing stunting
 graph_titles: []
 graph_type: line
+indicator_available: Percent of US children ages 0 to 5 experiencing stunting
 indicator_name: global_indicators.2-2-1-title
-indicator_number: '2.2.1'
+indicator_number: 2.2.1
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/2-2-2.yml
+++ b/indicator-config/2-2-2.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,14 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.2-2-2-title
+graph_title: Percent of children ages 0 to 5 years with wasting (very low weight-for-length/height)
+  in the US
 graph_titles: []
 graph_type: line
+indicator_available: Percent of children ages 0 to 5 years with wasting (very low
+  weight-for-length/height) in the US
 indicator_name: global_indicators.2-2-2-title
-indicator_number: '2.2.2'
+indicator_number: 2.2.2
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/3-1-2.yml
+++ b/indicator-config/3-1-2.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,12 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.3-1-2-title
+graph_title: Percentage of US births attended by by skilled health personnel
 graph_titles: []
 graph_type: line
+indicator_available: Percentage of US births attended by by skilled health personnel
 indicator_name: global_indicators.3-1-2-title
-indicator_number: '3.1.2'
+indicator_number: 3.1.2
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/3-2-1.yml
+++ b/indicator-config/3-2-1.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,13 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.3-2-1-title
+graph_title: Mortality rate for US infants and children younger than 5 years old
 graph_titles: []
 graph_type: line
+indicator_available: Mortality rate for US infants and children younger than 5 years
+  old
 indicator_name: global_indicators.3-2-1-title
-indicator_number: '3.2.1'
+indicator_number: 3.2.1
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/3-2-2.yml
+++ b/indicator-config/3-2-2.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,13 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.3-2-2-title
+graph_title: Number of deaths (infants aged 0 to 27 days old) per 1,000 US live births
 graph_titles: []
 graph_type: line
+indicator_available: Number of deaths (infants aged 0 to 27 days old) per 1,000 US
+  live births
 indicator_name: global_indicators.3-2-2-title
-indicator_number: '3.2.2'
+indicator_number: 3.2.2
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/3-3-1.yml
+++ b/indicator-config/3-3-1.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,14 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.3-3-1-title
+graph_title: Number of new HIV diagnoses of HIV infection per 100,000 US population
+  by year of diagnosis
 graph_titles: []
 graph_type: line
+indicator_available: Number of new HIV diagnoses of HIV infection per 100,000 US population
+  by year of diagnosis
 indicator_name: global_indicators.3-3-1-title
-indicator_number: '3.3.1'
+indicator_number: 3.3.1
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/3-3-2.yml
+++ b/indicator-config/3-3-2.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,12 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.3-3-2-title
+graph_title: Tuberculosis incidence per 100,000 US population
 graph_titles: []
 graph_type: line
+indicator_available: Tuberculosis incidence per 100,000 US population
 indicator_name: global_indicators.3-3-2-title
-indicator_number: '3.3.2'
+indicator_number: 3.3.2
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/3-3-3.yml
+++ b/indicator-config/3-3-3.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,14 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.3-3-3-title
+graph_title: Are there statistically-significant cases of malaria (unrelated to travel)
+  in the US?
 graph_titles: []
 graph_type: line
+indicator_available: Are there statistically-significant cases of malaria (unrelated
+  to travel) in the US?
 indicator_name: global_indicators.3-3-3-title
-indicator_number: '3.3.3'
+indicator_number: 3.3.3
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/3-3-4.yml
+++ b/indicator-config/3-3-4.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,12 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.3-3-4-title
+graph_title: Reported acute hepatitis B cases per 100,000 US population
 graph_titles: []
 graph_type: line
+indicator_available: Reported acute hepatitis B cases per 100,000 US population
 indicator_name: global_indicators.3-3-4-title
-indicator_number: '3.3.4'
+indicator_number: 3.3.4
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/3-4-1.yml
+++ b/indicator-config/3-4-1.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,14 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.3-4-1-title
+graph_title: US crude mortality rate due to cardiovascular disease, malignant neoplasms,
+  diabetes and chronic lower respiratory disease
 graph_titles: []
 graph_type: line
+indicator_available: US crude mortality rate due to cardiovascular disease, malignant
+  neoplasms, diabetes and chronic lower respiratory disease
 indicator_name: global_indicators.3-4-1-title
-indicator_number: '3.4.1'
+indicator_number: 3.4.1
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/3-4-2.yml
+++ b/indicator-config/3-4-2.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,12 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.3-4-2-title
+graph_title: US crude suicide mortality rate
 graph_titles: []
 graph_type: line
+indicator_available: US crude suicide mortality rate
 indicator_name: global_indicators.3-4-2-title
-indicator_number: '3.4.2'
+indicator_number: 3.4.2
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/3-5-2.yml
+++ b/indicator-config/3-5-2.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,14 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.3-5-2-title
+graph_title: Percent of US persons 12 years of age and older reporting current heavy
+  alcohol consumption
 graph_titles: []
 graph_type: line
+indicator_available: Percent of US persons 12 years of age and older reporting current
+  heavy alcohol consumption
 indicator_name: global_indicators.3-5-2-title
-indicator_number: '3.5.2'
+indicator_number: 3.5.2
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/3-6-1.yml
+++ b/indicator-config/3-6-1.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,14 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.3-6-1-title
+graph_title: Age-adjusted rate of deaths due to road traffic injuries per 100,000
+  US population
 graph_titles: []
 graph_type: line
+indicator_available: Age-adjusted rate of deaths due to road traffic injuries per
+  100,000 US population
 indicator_name: global_indicators.3-6-1-title
-indicator_number: '3.6.1'
+indicator_number: 3.6.1
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/3-7-1.yml
+++ b/indicator-config/3-7-1.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,13 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.3-7-1-title
+graph_title: Percentage of US women ages 15-44 currently using any method of contraception
 graph_titles: []
 graph_type: line
+indicator_available: Percentage of US women ages 15-44 currently using any method
+  of contraception
 indicator_name: global_indicators.3-7-1-title
-indicator_number: '3.7.1'
+indicator_number: 3.7.1
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/3-7-2.yml
+++ b/indicator-config/3-7-2.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,14 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.3-7-2-title
+graph_title: US adolescent birth rate (aged 15-19 years) per 1,000 women in that age
+  group
 graph_titles: []
 graph_type: line
+indicator_available: US adolescent birth rate (aged 15-19 years) per 1,000 women in
+  that age group
 indicator_name: global_indicators.3-7-2-title
-indicator_number: '3.7.2'
+indicator_number: 3.7.2
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/3-9-3.yml
+++ b/indicator-config/3-9-3.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,12 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.3-9-3-title
+graph_title: US crude rate of death due to unintentional poisoning
 graph_titles: []
 graph_type: line
+indicator_available: US crude rate of death due to unintentional poisoning
 indicator_name: global_indicators.3-9-3-title
-indicator_number: '3.9.3'
+indicator_number: 3.9.3
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/3-a-1.yml
+++ b/indicator-config/3-a-1.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,12 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.3-a-1-title
+graph_title: Percentage of US population aged 18 and over who are daily smokers
 graph_titles: []
 graph_type: line
+indicator_available: Percentage of US population aged 18 and over who are daily smokers
 indicator_name: global_indicators.3-a-1-title
-indicator_number: '3.a.1'
+indicator_number: 3.a.1
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/3-c-1.yml
+++ b/indicator-config/3-c-1.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,12 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.3-c-1-title
+graph_title: US health care workers per 1000 population
 graph_titles: []
 graph_type: line
+indicator_available: US health care workers per 1000 population
 indicator_name: global_indicators.3-c-1-title
-indicator_number: '3.c.1'
+indicator_number: 3.c.1
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/4-1-1.yml
+++ b/indicator-config/4-1-1.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,13 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.4-1-1-title
+graph_title: Percentage 4th grade students at or above "basic" proficiency in reading
 graph_titles: []
 graph_type: line
+indicator_available: Percentage 4th grade students at or above "basic" proficiency
+  in reading
 indicator_name: global_indicators.4-1-1-title
-indicator_number: '4.1.1'
+indicator_number: 4.1.1
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/4-2-1.yml
+++ b/indicator-config/4-2-1.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,12 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.4-2-1-title
+graph_title: Early math skills among US kindergarteners (typically age 5)
 graph_titles: []
 graph_type: line
+indicator_available: Early math skills among US kindergarteners (typically age 5)
 indicator_name: global_indicators.4-2-1-title
-indicator_number: '4.2.1'
+indicator_number: 4.2.1
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/4-2-2.yml
+++ b/indicator-config/4-2-2.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,14 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.4-2-2-title
+graph_title: Percentage of 5 years olds enrolled in prekindergarten, kindergarten,
+  or first or higher grade in the US
 graph_titles: []
 graph_type: line
+indicator_available: Percentage of 5 years olds enrolled in prekindergarten, kindergarten,
+  or first or higher grade in the US
 indicator_name: global_indicators.4-2-2-title
-indicator_number: '4.2.2'
+indicator_number: 4.2.2
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/4-3-1.yml
+++ b/indicator-config/4-3-1.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,14 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.4-3-1-title
+graph_title: Percentage of persons in US ages 16 to 65 enrolling in formal educational
+  programs during the past year
 graph_titles: []
 graph_type: line
+indicator_available: Percentage of persons in US ages 16 to 65 enrolling in formal
+  educational programs during the past year
 indicator_name: global_indicators.4-3-1-title
-indicator_number: '4.3.1'
+indicator_number: 4.3.1
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/4-4-1.yml
+++ b/indicator-config/4-4-1.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,14 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.4-4-1-title
+graph_title: Percentage of US persons ages 16 to 65 performing at level 2 or higher
+  of the PIAAC Problem Solving in Technology-Rich Environments
 graph_titles: []
 graph_type: line
+indicator_available: Percentage of US persons ages 16 to 65 performing at level 2
+  or higher of the PIAAC Problem Solving in Technology-Rich Environments
 indicator_name: global_indicators.4-4-1-title
-indicator_number: '4.4.1'
+indicator_number: 4.4.1
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/4-5-1.yml
+++ b/indicator-config/4-5-1.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,12 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.4-5-1-title
+graph_title: US Reading literacy among 4th graders
 graph_titles: []
 graph_type: line
+indicator_available: US Reading literacy among 4th graders
 indicator_name: global_indicators.4-5-1-title
-indicator_number: '4.5.1'
+indicator_number: 4.5.1
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/4-6-1.yml
+++ b/indicator-config/4-6-1.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,14 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.4-6-1-title
+graph_title: Percentage of US persons ages 16 to 65 performing at level 3 or higher
+  of the PIAAC literacy or numeracy measure, by sex, age, and income
 graph_titles: []
 graph_type: line
+indicator_available: Percentage of US persons ages 16 to 65 performing at level 3
+  or higher of the PIAAC literacy or numeracy measure, by sex, age, and income
 indicator_name: global_indicators.4-6-1-title
-indicator_number: '4.6.1'
+indicator_number: 4.6.1
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/4-7-1.yml
+++ b/indicator-config/4-7-1.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,14 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.4-7-1-title
+graph_title: Percentage of US 8th graders attending public or private schools that
+  emphasize "world affairs" to a moderate or great extent
 graph_titles: []
 graph_type: line
+indicator_available: Percentage of US 8th graders attending public or private schools
+  that emphasize "world affairs" to a moderate or great extent
 indicator_name: global_indicators.4-7-1-title
-indicator_number: '4.7.1'
+indicator_number: 4.7.1
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/4-a-1.yml
+++ b/indicator-config/4-a-1.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,16 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.4-a-1-title
+graph_title: Percentage of public schools with Internet access for student use. Estimated
+  percentage of public schools with basic drinking water, sanitation facilities, and
+  hand washing facilities.
 graph_titles: []
 graph_type: line
+indicator_available: Percentage of public schools with Internet access for student
+  use. Estimated percentage of public schools with basic drinking water, sanitation
+  facilities, and hand washing facilities.
 indicator_name: global_indicators.4-a-1-title
-indicator_number: '4.a.1'
+indicator_number: 4.a.1
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/4-b-1.yml
+++ b/indicator-config/4-b-1.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,12 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.4-b-1-title
+graph_title: USAID assistance for education development assistance in US dollars
 graph_titles: []
 graph_type: line
+indicator_available: USAID assistance for education development assistance in US dollars
 indicator_name: global_indicators.4-b-1-title
-indicator_number: '4.b.1'
+indicator_number: 4.b.1
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/4-c-1.yml
+++ b/indicator-config/4-c-1.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,12 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.4-c-1-title
+graph_title: Percent of US public school pre-primary teachers with certification
 graph_titles: []
 graph_type: line
+indicator_available: Percent of US public school pre-primary teachers with certification
 indicator_name: global_indicators.4-c-1-title
-indicator_number: '4.c.1'
+indicator_number: 4.c.1
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/5-2-1.yml
+++ b/indicator-config/5-2-1.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,12 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.5-2-1-title
+graph_title: Estimated number of rapes in US
 graph_titles: []
 graph_type: line
+indicator_available: Estimated number of rapes in US
 indicator_name: global_indicators.5-2-1-title
-indicator_number: '5.2.1'
+indicator_number: 5.2.1
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/5-2-2.yml
+++ b/indicator-config/5-2-2.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,12 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.5-2-2-title
+graph_title: See US data and metadata for indicator 5.2.1.
 graph_titles: []
 graph_type: line
+indicator_available: See US data and metadata for indicator 5.2.1.
 indicator_name: global_indicators.5-2-2-title
-indicator_number: '5.2.2'
+indicator_number: 5.2.2
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/5-4-1.yml
+++ b/indicator-config/5-4-1.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,13 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.5-4-1-title
+graph_title: Hours per day spent on household activities by US women ages 15 and older
 graph_titles: []
 graph_type: line
+indicator_available: Hours per day spent on household activities by US women ages
+  15 and older
 indicator_name: global_indicators.5-4-1-title
-indicator_number: '5.4.1'
+indicator_number: 5.4.1
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/5-5-1.yml
+++ b/indicator-config/5-5-1.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,13 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.5-5-1-title
+graph_title: Percent of Women in the US Congress and in Statewide Executive Office
 graph_titles: []
 graph_type: line
+indicator_available: Percent of Women in the US Congress and in Statewide Executive
+  Office
 indicator_name: global_indicators.5-5-1-title
-indicator_number: '5.5.1'
+indicator_number: 5.5.1
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/5-5-2.yml
+++ b/indicator-config/5-5-2.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,14 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.5-5-2-title
+graph_title: Percent of US women ages 16 and older in full-time, civilian management
+  occupations
 graph_titles: []
 graph_type: line
+indicator_available: Percent of US women ages 16 and older in full-time, civilian
+  management occupations
 indicator_name: global_indicators.5-5-2-title
-indicator_number: '5.5.2'
+indicator_number: 5.5.2
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/5-b-1.yml
+++ b/indicator-config/5-b-1.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,14 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.5-b-1-title
+graph_title: Percent of US females ages 3 and older who use an Internet-connected
+  mobile telephone
 graph_titles: []
 graph_type: line
+indicator_available: Percent of US females ages 3 and older who use an Internet-connected
+  mobile telephone
 indicator_name: global_indicators.5-b-1-title
-indicator_number: '5.b.1'
+indicator_number: 5.b.1
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/6-1-1.yml
+++ b/indicator-config/6-1-1.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,14 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.6-1-1-title
+graph_title: Percent of US population that receives drinking water from community
+  water systems in compliance with drinking water standards
 graph_titles: []
 graph_type: line
+indicator_available: Percent of US population that receives drinking water from community
+  water systems in compliance with drinking water standards
 indicator_name: global_indicators.6-1-1-title
-indicator_number: '6.1.1'
+indicator_number: 6.1.1
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/6-5-1.yml
+++ b/indicator-config/6-5-1.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,12 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.6-5-1-title
+graph_title: Estimated acres of US farm land irrigated
 graph_titles: []
 graph_type: line
+indicator_available: Estimated acres of US farm land irrigated
 indicator_name: global_indicators.6-5-1-title
-indicator_number: '6.5.1'
+indicator_number: 6.5.1
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/7-1-1.yml
+++ b/indicator-config/7-1-1.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,14 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.7-1-1-title
+graph_title: Proportion of occupied housing units in metropolitan areas with access
+  to electricity
 graph_titles: []
 graph_type: line
+indicator_available: Proportion of occupied housing units in metropolitan areas with
+  access to electricity
 indicator_name: global_indicators.7-1-1-title
-indicator_number: '7.1.1'
+indicator_number: 7.1.1
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/7-2-1.yml
+++ b/indicator-config/7-2-1.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,14 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.7-2-1-title
+graph_title: US renewable energy consumption as a percentage of total final energy
+  consumption
 graph_titles: []
 graph_type: line
+indicator_available: US renewable energy consumption as a percentage of total final
+  energy consumption
 indicator_name: global_indicators.7-2-1-title
-indicator_number: '7.2.1'
+indicator_number: 7.2.1
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/7-3-1.yml
+++ b/indicator-config/7-3-1.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,14 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.7-3-1-title
+graph_title: US Total Primary Energy Consumption per Real Dollar of GDP (Thousand
+  Btu per Chained (2012) Dollar)
 graph_titles: []
 graph_type: line
+indicator_available: US Total Primary Energy Consumption per Real Dollar of GDP (Thousand
+  Btu per Chained (2012) Dollar)
 indicator_name: global_indicators.7-3-1-title
-indicator_number: '7.3.1'
+indicator_number: 7.3.1
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/8-1-1.yml
+++ b/indicator-config/8-1-1.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,13 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.8-1-1-title
+graph_title: US annual growth rate of per capita GDP in chained (2012) US dollars
 graph_titles: []
 graph_type: line
+indicator_available: US annual growth rate of per capita GDP in chained (2012) US
+  dollars
 indicator_name: global_indicators.8-1-1-title
-indicator_number: '8.1.1'
+indicator_number: 8.1.1
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/8-10-1.yml
+++ b/indicator-config/8-10-1.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,12 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.8-10-1-title
+graph_title: Number of US commercial banking establishments
 graph_titles: []
 graph_type: line
+indicator_available: Number of US commercial banking establishments
 indicator_name: global_indicators.8-10-1-title
-indicator_number: '8.10.1'
+indicator_number: 8.10.1
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/8-10-2.yml
+++ b/indicator-config/8-10-2.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,14 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.8-10-2-title
+graph_title: Proportion of U.S. households with a checking account, savings account,
+  money market account, or certificate of deposit
 graph_titles: []
 graph_type: line
+indicator_available: Proportion of U.S. households with a checking account, savings
+  account, money market account, or certificate of deposit
 indicator_name: global_indicators.8-10-2-title
-indicator_number: '8.10.2'
+indicator_number: 8.10.2
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/8-2-1.yml
+++ b/indicator-config/8-2-1.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,12 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.8-2-1-title
+graph_title: US annual growth rate of business sector output per job
 graph_titles: []
 graph_type: line
+indicator_available: US annual growth rate of business sector output per job
 indicator_name: global_indicators.8-2-1-title
-indicator_number: '8.2.1'
+indicator_number: 8.2.1
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/8-4-2.yml
+++ b/indicator-config/8-4-2.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,12 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.8-4-2-title
+graph_title: US personal consumption expenditure (goods) per capita
 graph_titles: []
 graph_type: line
+indicator_available: US personal consumption expenditure (goods) per capita
 indicator_name: global_indicators.8-4-2-title
-indicator_number: '8.4.2'
+indicator_number: 8.4.2
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/8-5-1.yml
+++ b/indicator-config/8-5-1.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,14 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.8-5-1-title
+graph_title:  Median weekly earnings in US dollars of women ages 16 and over who indicated
+  they have a disability, employed as full-time wage and salary workers
 graph_titles: []
 graph_type: line
+indicator_available:  Median weekly earnings in US dollars of women ages 16 and over
+  who indicated they have a disability, employed as full-time wage and salary workers
 indicator_name: global_indicators.8-5-1-title
-indicator_number: '8.5.1'
+indicator_number: 8.5.1
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/8-5-2.yml
+++ b/indicator-config/8-5-2.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,14 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.8-5-2-title
+graph_title:  Unemployment rate among men with disability, ages 16 and older, 2009-16
+  annual averages
 graph_titles: []
 graph_type: line
+indicator_available:  Unemployment rate among men with disability, ages 16 and older,
+  2009-16 annual averages
 indicator_name: global_indicators.8-5-2-title
-indicator_number: '8.5.2'
+indicator_number: 8.5.2
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/8-6-1.yml
+++ b/indicator-config/8-6-1.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,14 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.8-6-1-title
+graph_title:  Percent of US population 16 to 24 years who are not enrolled in school
+  and are either unemployed or not in the labor force
 graph_titles: []
 graph_type: line
+indicator_available:  Percent of US population 16 to 24 years who are not enrolled
+  in school and are either unemployed or not in the labor force
 indicator_name: global_indicators.8-6-1-title
-indicator_number: '8.6.1'
+indicator_number: 8.6.1
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/8-8-1.yml
+++ b/indicator-config/8-8-1.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,14 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.8-8-1-title
+graph_title: US Incidence of fatal occupational injuries per 100,000 male fulltime
+  workers
 graph_titles: []
 graph_type: line
+indicator_available: US Incidence of fatal occupational injuries per 100,000 male
+  fulltime workers
 indicator_name: global_indicators.8-8-1-title
-indicator_number: '8.8.1'
+indicator_number: 8.8.1
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/8-9-1.yml
+++ b/indicator-config/8-9-1.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,12 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.8-9-1-title
+graph_title: Growth Rate of Direct Tourism GDP as a Proportion of Total GDP
 graph_titles: []
 graph_type: line
+indicator_available: Growth Rate of Direct Tourism GDP as a Proportion of Total GDP
 indicator_name: global_indicators.8-9-1-title
-indicator_number: '8.9.1'
+indicator_number: 8.9.1
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/8-a-1.yml
+++ b/indicator-config/8-a-1.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,14 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.8-a-1-title
+graph_title: 'Total ODA disbursements in support of Aid for Trade in millions of US
+  dollars '
 graph_titles: []
 graph_type: line
+indicator_available: 'Total ODA disbursements in support of Aid for Trade in millions
+  of US dollars '
 indicator_name: global_indicators.8-a-1-title
-indicator_number: '8.a.1'
+indicator_number: 8.a.1
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/9-1-2.yml
+++ b/indicator-config/9-1-2.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,12 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.9-1-2-title
+graph_title: US passenger and freight data by mode in millions
 graph_titles: []
 graph_type: line
+indicator_available: US passenger and freight data by mode in millions
 indicator_name: global_indicators.9-1-2-title
-indicator_number: '9.1.2'
+indicator_number: 9.1.2
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/9-2-1.yml
+++ b/indicator-config/9-2-1.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,12 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.9-2-1-title
+graph_title: US manufacturing value added as a percentage of GDP
 graph_titles: []
 graph_type: line
+indicator_available: US manufacturing value added as a percentage of GDP
 indicator_name: global_indicators.9-2-1-title
-indicator_number: '9.2.1'
+indicator_number: 9.2.1
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/9-2-2.yml
+++ b/indicator-config/9-2-2.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,12 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.9-2-2-title
+graph_title: Percent of US manufacturing in total employment
 graph_titles: []
 graph_type: line
+indicator_available: Percent of US manufacturing in total employment
 indicator_name: global_indicators.9-2-2-title
-indicator_number: '9.2.2'
+indicator_number: 9.2.2
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/9-4-1.yml
+++ b/indicator-config/9-4-1.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,13 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.9-4-1-title
+graph_title: Carbon Dioxide Emissions in Metric Tons per Million Chained (2012) Dollars
 graph_titles: []
 graph_type: line
+indicator_available: Carbon Dioxide Emissions in Metric Tons per Million Chained (2012)
+  Dollars
 indicator_name: global_indicators.9-4-1-title
-indicator_number: '9.4.1'
+indicator_number: 9.4.1
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/9-5-1.yml
+++ b/indicator-config/9-5-1.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,12 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.9-5-1-title
+graph_title: US research and development expenditure as a proportion of GDP
 graph_titles: []
 graph_type: line
+indicator_available: US research and development expenditure as a proportion of GDP
 indicator_name: global_indicators.9-5-1-title
-indicator_number: '9.5.1'
+indicator_number: 9.5.1
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/indicator-config/9-c-1.yml
+++ b/indicator-config/9-c-1.yml
@@ -1,4 +1,4 @@
-﻿composite_breakdown_label: ''
+composite_breakdown_label: ''
 computation_units: ''
 copyright: ''
 data_footnote: ''
@@ -17,11 +17,13 @@ expected_disaggregations: []
 graph_annotations: []
 graph_limits: []
 graph_stacked_disaggregation: ''
-graph_title: global_indicators.9-c-1-title
+graph_title: Percentage of the U.S. population covered by at least a 3G mobile network
 graph_titles: []
 graph_type: line
+indicator_available: Percentage of the U.S. population covered by at least a 3G mobile
+  network
 indicator_name: global_indicators.9-c-1-title
-indicator_number: '9.c.1'
+indicator_number: 9.c.1
 national_geographical_coverage: ''
 page_content: ''
 permalink: ''

--- a/scripts/batch/recover_graph_titles.py
+++ b/scripts/batch/recover_graph_titles.py
@@ -1,0 +1,38 @@
+import sdg
+import os
+import yaml
+
+"""
+This is a one-time script to recover some US-specific config.
+"""
+
+# Get the metadata for an indicator.
+def get_metadata(filepath):
+    with open(filepath, 'r') as stream:
+        try:
+            for doc in yaml.safe_load_all(stream):
+                if hasattr(doc, 'items'):
+                    return doc
+        except yaml.YAMLError as e:
+            print(e)
+
+def write_metadata(filepath, metadata):
+    yaml_string = yaml.dump(metadata,
+        allow_unicode=True)
+    with open(filepath, 'w') as outfile:
+        outfile.write(yaml_string)
+
+ids = sdg.path.get_ids()
+for inid in ids:
+    filepath = os.path.join('indicator-config', inid + '.yml')
+    if os.path.isfile(filepath):
+        meta = get_metadata(filepath)
+        old_filepath = os.path.join('..', 'sdg-data-usa', 'meta', inid + '.md')
+        old_meta = get_metadata(old_filepath)
+
+        # In some cases the US graph_title was different from the
+        # global indicator name.
+        if old_meta['indicator_name'] != old_meta['graph_title']:
+            meta['indicator_available'] = old_meta['graph_title']
+            meta['graph_title'] = old_meta['graph_title']
+            write_metadata(filepath, meta)


### PR DESCRIPTION
There were some US-specific "graph titles" in the old repository and this one-time script pulled them in and set them as "graph_title" and "indicator_available".