### PR TITLE
Metadata alterations: remove numbers from global metadata

### DIFF
--- a/scripts/alterations.py
+++ b/scripts/alterations.py
@@ -20,9 +20,4 @@ def alter_meta(meta, context):
         if key in meta:
             meta[key] = remove_global_numbers(meta[key])
 
-    # If "actual_indicator_available" is populated, use it for
-    # the indicator config settings: indicator_available and graph_title.
-    if 'actual_indicator_available' in meta and meta['actual_indicator_available'] != '':
-        meta['indicator_available'] = meta['actual_indicator_available']
-        meta['graph_title'] = meta['actual_indicator_available']
     return meta

--- a/scripts/alterations.py
+++ b/scripts/alterations.py
@@ -15,8 +15,14 @@ def alter_meta(meta, context):
         return re.sub(pattern, '', input_string)
 
     
+    # Remove the numbers from the global indicator/target/goal names.
     for key in ['SDG_GOAL__GLOBAL', 'SDG_TARGET__GLOBAL', 'SDG_INDICATOR__GLOBAL']:
         if key in meta:
             meta[key] = remove_global_numbers(meta[key])
 
+    # If "actual_indicator_available" is populated, use it for
+    # the indicator config settings: indicator_available and graph_title.
+    if 'actual_indicator_available' in meta and meta['actual_indicator_available'] != '':
+        meta['indicator_available'] = meta['actual_indicator_available']
+        meta['graph_title'] = meta['actual_indicator_available']
     return meta

--- a/scripts/alterations.py
+++ b/scripts/alterations.py
@@ -1,0 +1,22 @@
+import re
+
+def alter_data(df, context):
+    return df
+
+
+def alter_meta(meta, context):
+    def remove_global_numbers(input_string):
+        """
+        Global metadata includes numbers before the indicator/target/goal numbers.
+        We would like to remove them, since they sometimes do not match the current
+        indicator.
+        """
+        pattern = r'(Indicator .*\..*\..*|Target .*\.*|Goal .*): '
+        return re.sub(pattern, '', input_string)
+
+    
+    for key in ['SDG_GOAL__GLOBAL', 'SDG_TARGET__GLOBAL', 'SDG_INDICATOR__GLOBAL']:
+        if key in meta:
+            meta[key] = remove_global_numbers(meta[key])
+
+    return meta

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -1,3 +1,5 @@
 from sdg.open_sdg import open_sdg_build
+from alterations import alter_meta
+from alterations import alter_data
 
-open_sdg_build(config='config_data.yml')
+open_sdg_build(config='config_data.yml', alter_meta=alter_meta, alter_data=alter_data)

--- a/scripts/check_data.py
+++ b/scripts/check_data.py
@@ -1,7 +1,9 @@
 from sdg.open_sdg import open_sdg_check
+from alterations import alter_meta
+from alterations import alter_data
 
 # Validate the indicators.
-validation_successful = open_sdg_check(config='config_data.yml')
+validation_successful = open_sdg_check(config='config_data.yml', alter_meta=alter_meta, alter_data=alter_data)
 
 # If everything was valid, perform the build.
 if not validation_successful:


### PR DESCRIPTION
The indicator/target/goal names in the global metadata include numbers, which don't always match with a particular indicator number. To avoid confusion, this PR removes them using a regex.

It also adds the "plumbing" necessary to do other alterations of data or metadata in the future.